### PR TITLE
Add Tekton PipelineRuns for SonarQube plugin and build, along with Do…

### DIFF
--- a/.tekton/plugin-pipelinerun.yaml
+++ b/.tekton/plugin-pipelinerun.yaml
@@ -1,0 +1,100 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: sonarqube-plugin
+  annotations:
+    pipelinesascode.tekton.dev/on-comment: "^((/sonarqube-plugin)|(/test-all))$"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      "plugin/plugins.txt".pathChanged() && "plugin/Dockerfile".pathChanged() && ((
+        event == "push" && (
+          source_branch.matches("^(alauda/.*)$") ||
+          target_branch.startsWith("refs/tags/")
+        )
+      ) || (
+        event == "pull_request" && (
+          target_branch.matches("^(alauda/.*)$")
+        )
+      ))
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  pipelineRef:
+    resolver: hub
+    params:
+    - name: catalog
+      value: alauda
+    - name: type
+      value: tekton
+    - name: kind
+      value: pipeline
+    - name: name
+      value: clone-image-build-test-scan
+    - name: version
+      value: "0.2"
+
+  params:
+    - name: git-url
+      value: "{{ repo_url }}"
+    - name: git-revision
+      value: "{{ source_branch }}"
+    - name: git-commit
+      value: "{{ revision }}"
+
+    - name: image-repository
+      value: build-harbor.alauda.cn/devops/sonarqube-plugins
+
+    - name: tags
+      value:
+        - v9.9.8
+    - name: dockerfile-path
+      value: plugin/Dockerfile
+    
+    - name: context
+      value: ./plugin
+
+    - name: file-list-for-commit-sha
+      value:
+        - plugin/
+
+    ## Some JAR files in the plugin installation package contain application vulnerabilities. Currently there are no new versions available.
+    ## Need to wait for the community to release new versions before upgrading. Therefore, temporarily skip trivy scanning.
+    - name: ignore-trivy-scan
+      value: true
+
+    # - name: test-script
+    #   value: |
+    #     echo skip
+
+    # - name: upstreams
+    #   value:
+    #     - repo-url: https://github.com/example/repo.git
+    #       branch-name: main
+    #       yaml-file-path: chart/values.yaml
+
+    # - name: upstream-secret
+    #   value: git-repo-example-secret
+
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
+    - name: dockerconfig
+      secret:
+        secretName: build-harbor.kauto.docfj
+    # This secret will be replaced by the pac controller
+    - name: basic-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"
+
+  taskRunTemplate:
+    # 让所有任务都以非 root 用户运行。
+    podTemplate:
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: "OnRootMismatch"

--- a/.tekton/sonar-pipelinerun.yaml
+++ b/.tekton/sonar-pipelinerun.yaml
@@ -1,0 +1,100 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: sonarqube-build
+  annotations:
+    pipelinesascode.tekton.dev/on-comment: "^((/sonarqube-build)|(/test-all))$"
+    pipelinesascode.tekton.dev/on-cel-expression: |-
+      ((
+        event == "push" && (
+          source_branch.matches("^(alauda/.*)$") ||
+          target_branch.startsWith("refs/tags/")
+        )
+      ) || (
+        event == "pull_request" && (
+          target_branch.matches("^(alauda/.*)$")
+        )
+      ))
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  pipelineRef:
+    resolver: hub
+    params:
+    - name: catalog
+      value: alauda
+    - name: type
+      value: tekton
+    - name: kind
+      value: pipeline
+    - name: name
+      value: clone-image-build-test-scan
+    - name: version
+      value: "0.2"
+
+  params:
+    - name: git-url
+      value: "{{ repo_url }}"
+    - name: git-revision
+      value: "{{ source_branch }}"
+    - name: git-commit
+      value: "{{ revision }}"
+
+    - name: image-repository
+      value: build-harbor.alauda.cn/devops/sonarqube
+
+    - name: tags
+      value:
+        - v9.9.8
+    - name: context
+      value: 9/community/
+
+    - name: dockerfile-path
+      value: 9/community/Dockerfile
+
+    - name: file-list-for-commit-sha
+      value:
+        - 9/community/
+    
+    ## Some JAR files in the SonarQube installation package contain application vulnerabilities. Currently there are no new versions available.
+    ## Need to wait for the community to release new versions before upgrading. Therefore, temporarily skip trivy scanning.
+    - name: ignore-trivy-scan
+      value: true
+
+    # - name: test-script
+    #   value: |
+    #     echo skip
+
+    # - name: upstreams
+    #   value:
+    #     - repo-url: https://github.com/example/repo.git
+    #       branch-name: main
+    #       yaml-file-path: chart/values.yaml
+
+    # - name: upstream-secret
+    #   value: git-repo-example-secret
+
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 1Gi
+    - name: dockerconfig
+      secret:
+        secretName: build-harbor.kauto.docfj
+    # This secret will be replaced by the pac controller
+    - name: basic-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"
+
+  taskRunTemplate:
+    # 让所有任务都以非 root 用户运行。
+    podTemplate:
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: "OnRootMismatch"

--- a/9/community/Dockerfile
+++ b/9/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-jammy
+FROM docker-mirrors.alauda.cn/library/eclipse-temurin:17-jre-jammy
 
 LABEL org.opencontainers.image.url=https://github.com/SonarSource/docker-sonarqube
 
@@ -51,7 +51,7 @@ RUN set -eux; \
     ln -s "${SONARQUBE_HOME}/lib/sonar-application-${SONARQUBE_VERSION}.jar" "${SONARQUBE_HOME}/lib/sonarqube.jar"; \
     chmod -R 555 ${SONARQUBE_HOME}; \
     chmod -R ugo+wrX "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
-    apt-get remove -y gnupg unzip curl; \
+    apt-get remove -y gnupg unzip; \
     rm -rf /var/lib/apt/lists/*;
 
 COPY entrypoint.sh ${SONARQUBE_HOME}/docker/

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -1,0 +1,5 @@
+FROM build-harbor.alauda.cn/ops/alpine:3
+
+ADD plugins.txt /tmp/plugins/
+WORKDIR /tmp/plugins
+RUN apk add --no-cache wget && wget -c -q -i ./plugins.txt

--- a/plugin/plugins.txt
+++ b/plugin/plugins.txt
@@ -1,0 +1,3 @@
+https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/1.14.0/sonarqube-community-branch-plugin-1.14.0.jar
+https://github.com/vaulttec/sonar-auth-oidc/releases/download/v2.1.1/sonar-auth-oidc-plugin-2.1.1.jar
+https://github.com/spotbugs/sonar-findbugs/releases/download/v4.3.0/sonar-findbugs-plugin-4.3.0.jar


### PR DESCRIPTION
…ckerfile and plugin list

- Created two new PipelineRun configurations: `sonarqube-plugin` and `sonarqube-build` for managing SonarQube plugin builds.
- Added a Dockerfile to build the SonarQube plugin environment, which fetches plugins listed in `plugin.txt`.
- Introduced `plugin.txt` containing URLs for necessary SonarQube plugins.

These changes enhance the CI/CD process for SonarQube plugin development and deployment.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

Please be aware that we are not actively looking for feature contributions. We typically accept minor improvements and bug-fixes. 
Please ensure your pull request adheres to the following guidelines:
- [ ] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] If the PR modifies or adds images, use the `run-tests.sh imagedir` command to verify the image works
- [ ] If the PR modifies or adds images, try to make sure the images run correctly on Linux
